### PR TITLE
Fix mergeFamily out-of-range error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # Boiler plate for bulding Docker containers.
 # All this must go at top of file I'm afraid.
-IMAGE_PREFIX := weaveworks
+IMAGE_PREFIX := quay.io/weaveworks
 IMAGE_TAG := $(shell ./tools/image-tag)
 UPTODATE := .uptodate
 
@@ -80,5 +80,3 @@ clean:
 	$(SUDO) docker rmi $(IMAGE_NAMES) >/dev/null 2>&1 || true
 	rm -rf $(UPTODATE_FILES) $(EXES)
 	go clean ./...
-
-

--- a/cmd/prom-aggregation-gateway/main.go
+++ b/cmd/prom-aggregation-gateway/main.go
@@ -134,7 +134,7 @@ func mergeFamily(a, b *dto.MetricFamily) (*dto.MetricFamily, error) {
 		if lablesLessThan(a.Metric[i].Label, b.Metric[j].Label) {
 			output.Metric = append(output.Metric, a.Metric[i])
 			i++
-		} else if lablesLessThan(b.Metric[i].Label, a.Metric[j].Label) {
+		} else if lablesLessThan(b.Metric[j].Label, a.Metric[i].Label) {
 			output.Metric = append(output.Metric, b.Metric[j])
 			j++
 		} else {

--- a/cmd/prom-aggregation-gateway/main_test.go
+++ b/cmd/prom-aggregation-gateway/main_test.go
@@ -82,13 +82,27 @@ histogram_count 2
 # TYPE counter counter
 counter{a="a",b="b"} 1
 `
-	multilable2 = `# HELP counter A counter
+	multilabel2 = `# HELP counter A counter
 # TYPE counter counter
 counter{a="a",b="b"} 2
 `
 	multilabelResult = `# HELP counter A counter
 # TYPE counter counter
 counter{a="a",b="b"} 3
+`
+	labelFields1 = `# HELP ui_page_render_errors A counter
+# TYPE ui_page_render_errors counter
+ui_page_render_errors{path="/org/:orgId"} 1
+ui_page_render_errors{path="/prom/:orgId"} 1
+`
+	labelFields2 = `# HELP ui_page_render_errors A counter
+# TYPE ui_page_render_errors counter
+ui_page_render_errors{path="/prom/:orgId"} 1
+`
+	labelFieldResult = `# HELP ui_page_render_errors A counter
+# TYPE ui_page_render_errors counter
+ui_page_render_errors{path="/org/:orgId"} 1
+ui_page_render_errors{path="/prom/:orgId"} 2
 `
 )
 
@@ -98,7 +112,8 @@ func TestAggate(t *testing.T) {
 		want string
 	}{
 		{in1, in2, want},
-		{multilabel1, multilable2, multilabelResult},
+		{multilabel1, multilabel2, multilabelResult},
+		{labelFields1, labelFields2, labelFieldResult},
 	} {
 		a := newAggate()
 


### PR DESCRIPTION
There was a bug where sending a second increment to the same family would cause an out-of-range error. The only change was swapping the for-loop variables so they stay with their respective families. Also adds a test for the scenario in which the bug was found.