### PR TITLE
Fix duplicate metrics caused by different label ordering

### DIFF
--- a/cmd/prom-aggregation-gateway/main_test.go
+++ b/cmd/prom-aggregation-gateway/main_test.go
@@ -114,9 +114,9 @@ ui_external_lib_loaded{name="mixpanel",loaded="true"} 1
 `
 	gaugeOutput = `# HELP ui_external_lib_loaded A gauge with entries in un-sorted order
 # TYPE ui_external_lib_loaded gauge
-ui_external_lib_loaded{name="Intercom",loaded="true"} 2
-ui_external_lib_loaded{name="ga",loaded="true"} 2
-ui_external_lib_loaded{name="mixpanel",loaded="true"} 2
+ui_external_lib_loaded{loaded="true",name="Intercom"} 2
+ui_external_lib_loaded{loaded="true",name="ga"} 2
+ui_external_lib_loaded{loaded="true",name="mixpanel"} 2
 `
 	duplicateLabels = `
 # HELP ui_external_lib_loaded Test with duplicate values

--- a/cmd/prom-aggregation-gateway/main_test.go
+++ b/cmd/prom-aggregation-gateway/main_test.go
@@ -125,6 +125,19 @@ ui_external_lib_loaded{name="Munchkin",loaded="true"} 15171
 ui_external_lib_loaded{name="Munchkin",loaded="true"} 1
 `
 	duplicateError = `Duplicate labels: {__name__="ui_external_lib_loaded", loaded="true", name="Munchkin"}`
+
+	reorderedLabels1 = `# HELP counter A counter
+# TYPE counter counter
+counter{a="a",b="b"} 1
+`
+	reorderedLabels2 = `# HELP counter A counter
+# TYPE counter counter
+counter{b="b",a="a"} 2
+`
+	reorderedLabelsResult = `# HELP counter A counter
+# TYPE counter counter
+counter{a="a",b="b"} 3
+`
 )
 
 func TestAggate(t *testing.T) {
@@ -139,6 +152,7 @@ func TestAggate(t *testing.T) {
 		{multilabel1, multilabel2, multilabelResult, nil, nil},
 		{labelFields1, labelFields2, labelFieldResult, nil, nil},
 		{duplicateLabels, "", "", fmt.Errorf("%s", duplicateError), nil},
+		{reorderedLabels1, reorderedLabels2, reorderedLabelsResult, nil, nil},
 	} {
 		a := newAggate()
 


### PR DESCRIPTION
Sort labels after parsing, in case two clients send the same labels in different order.

Add a test for this case, and fix up another test that was affected.
