### PR TITLE
Add compatibility with prometheus/pushgateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,27 @@ Prometheus Aggregation Gateway is a aggregating push gateway for Prometheus.  As
 
 ## How to use
 
-Send metrics in [Prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/) to `/api/ui/metrics`
+Send metrics in [Prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/) to `/metrics/`
 
 E.g. if you have the program running locally:
 
-    echo 'http_requests_total{method="post",code="200"} 1027' | curl --data-binary @- http://localhost/api/ui/metrics
+```bash
+echo 'http_requests_total{method="post",code="200"} 1027' | curl --data-binary @- http://localhost/metrics/
+```
 
-Then have your Prometheus scrape metrics from the same address at `/metrics`.
+As `prom-aggregation-gateway` is compatible with `prometheus/pushgateway` in terms of protocol and API, you can push your metrics using your favorite Prometheus client.
+
+E.g. in Python using [prometheus/client_python](https://github.com/prometheus/client_python):
+
+```python
+from prometheus_client import CollectorRegistry, Counter, push_to_gateway
+registry = CollectorRegistry()
+counter = Counter('some_counter', "A counter", registry=registry)
+counter.inc()
+push_to_gateway('localhost', job='my_job_name', registry=registry)
+```
+
+Then have your Prometheus scrape metrics at `/metrics`.
 
 ## Ready-built images
 

--- a/cmd/prom-aggregation-gateway/main.go
+++ b/cmd/prom-aggregation-gateway/main.go
@@ -261,11 +261,12 @@ func (a *aggate) handler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	listen := flag.String("listen", ":80", "Address and port to listen on.")
 	cors := flag.String("cors", "*", "The 'Access-Control-Allow-Origin' value to be returned.")
+	pushPath := flag.String("push-path", "/metrics/", "HTTP path to accept pushed metrics.")
 	flag.Parse()
 
 	a := newAggate()
 	http.HandleFunc("/metrics", a.handler)
-	http.HandleFunc("/api/ui/metrics", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc(*pushPath, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", *cors)
 		if err := a.parseAndMerge(r.Body); err != nil {
 			log.Println(err)


### PR DESCRIPTION
Currently, it's not possible to push metrics to `/api/ui/metrics` using official Prometheus clients because the path is hard coded:
Go: https://github.com/prometheus/client_golang/blob/803ef2a759d7caaaa0de58e3815f1be4c8b5a42a/prometheus/push/push.go#L298
Python:  https://github.com/prometheus/client_python/blob/master/prometheus_client/exposition.py#L350
Java: https://github.com/prometheus/client_java/blob/master/simpleclient_pushgateway/src/main/java/io/prometheus/client/exporter/PushGateway.java#L84

Instead, let's make the default path `/metrics/` in order to be compatible with a wide range of Prometheus clients!

As `/api/ui/metrics` looks quite personal to weaveworks, it becomes configurable using the CLI.
Let me know if you want to manage this differently (even better if your ok to remove this config option)