### PR TITLE
Change endpoint in README from /metrics to /api/ui/metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Prometheus Aggregation Gateway is a aggregating push gateway for Prometheus.  As
 
 ## How to use
 
-Send metrics in [Prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/) to `/metrics/`
+Send metrics in [Prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/) to `/api/ui/metrics/`
 
 E.g. if you have the program running locally:
 
 ```bash
-echo 'http_requests_total{method="post",code="200"} 1027' | curl --data-binary @- http://localhost/metrics/
+echo 'http_requests_total{method="post",code="200"} 1027' | curl --data-binary @- http://localhost/api/ui/metrics/
 ```
 
 As `prom-aggregation-gateway` is compatible with `prometheus/pushgateway` in terms of protocol and API, you can push your metrics using your favorite Prometheus client.


### PR DESCRIPTION
When I try running this locally pushing to `localhost/metrics` does not work... pushing to `localhost/api/ui/metrics` does