### PR TITLE
Added the pushgateway health and ready endpoints

### DIFF
--- a/cmd/prom-aggregation-gateway/main.go
+++ b/cmd/prom-aggregation-gateway/main.go
@@ -258,6 +258,12 @@ func (a *aggate) handler(w http.ResponseWriter, r *http.Request) {
 	// TODO reset gauges
 }
 
+func handleHealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	io.WriteString(w, `{"alive": true}`)
+}
+
 func main() {
 	listen := flag.String("listen", ":80", "Address and port to listen on.")
 	cors := flag.String("cors", "*", "The 'Access-Control-Allow-Origin' value to be returned.")
@@ -266,6 +272,8 @@ func main() {
 
 	a := newAggate()
 	http.HandleFunc("/metrics", a.handler)
+	http.HandleFunc("/-/healthy", handleHealthCheck)
+	http.HandleFunc("/-/ready", handleHealthCheck)
 	http.HandleFunc(*pushPath, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", *cors)
 		if err := a.parseAndMerge(r.Body); err != nil {


### PR DESCRIPTION
-- By adding these endpoints the prom-aggregation-gateway
   can be deployed using the prometheus-pushgateway helm chart
   with the following values settings.
```
image:
  repository: weaveworks/prom-aggregation-gateway
  tag: master-XXXXXXXX
  pullPolicy: IfNotPresent

extraArgs: ["-listen", ":9091"]
```
-- This is the code for the helm chart health checks
   which fail otherwise.
```
   livenessProbe:
     httpGet:
       path: /-/healthy
       port: 9091
     initialDelaySeconds: 10
     timeoutSeconds: 10
   readinessProbe:
     httpGet:
       path: /-/ready
       port: 9091
     initialDelaySeconds: 10
     timeoutSeconds: 10
```

This is the repo for the pushgateway helm chart.
  https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-pushgateway