### PR TITLE
Change default POST endpoint to /metrics_push

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Prometheus Aggregation Gateway is a aggregating push gateway for Prometheus.  As
 
 ## How to use
 
-Send metrics in [Prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/) to `/metrics/`
+Send metrics in [Prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/) to `/metrics_push`
 
 E.g. if you have the program running locally:
 
 ```bash
-echo 'http_requests_total{method="post",code="200"} 1027' | curl --data-binary @- http://localhost/metrics/
+echo 'http_requests_total{method="post",code="200"} 1027' | curl --data-binary @- http://localhost/metrics_push
 ```
 
 Now you can push your metrics using your favorite Prometheus client.

--- a/cmd/prom-aggregation-gateway/main.go
+++ b/cmd/prom-aggregation-gateway/main.go
@@ -261,7 +261,7 @@ func (a *aggate) handler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	listen := flag.String("listen", ":80", "Address and port to listen on.")
 	cors := flag.String("cors", "*", "The 'Access-Control-Allow-Origin' value to be returned.")
-	pushPath := flag.String("push-path", "/metrics/", "HTTP path to accept pushed metrics.")
+	pushPath := flag.String("push-path", "/metrics_push", "HTTP path to accept pushed metrics.")
 	flag.Parse()
 
 	a := newAggate()


### PR DESCRIPTION
Before this change, the default read/write paths were as follows:
```
GET /metrics
POST /metrics/
```
this was SUPER confusing, as it was a very subtle difference in the documentation. Given the unconventional nature of employing trailing slashes to define/differentiate endpoints, hopefully this new default value will prevent other consumers of this API from going down the head-scratching path that I was on for a moment.