### PR TITLE
this adds a README update to checkout the zapier repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+
+🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
+
+**_Maintenance of project has moved_**
+No more contributions or issues are being accepted in this repo. If you woud like to send a PR or file a
+bug please go here:
+
+https://github.com/zapier/prom-aggregation-gateway
+
+🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
+
 # Prometheus Aggregation Gateway
 
 Prometheus Aggregation Gateway is a aggregating push gateway for Prometheus.  As opposed to the official [Prometheus Pushgateway](https://github.com/prometheus/pushgateway), this service aggregates the sample values it receives.


### PR DESCRIPTION
With regards to:

https://github.com/weaveworks/prom-aggregation-gateway/issues/78

I've opened up this PR to suggest anyone coming here checkout the zapier repo instead.  

cc @dholbach @monadic  -- Wasn't sure if this is what you had in mind but figured I'd open it up for discussion